### PR TITLE
support configuring a header interceptor (web)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "generate.spec.node": "./node_modules/.bin/openapi --input openapi.yaml --output ./src/api --useOptions --useUnionTypes --client node",
-    "generate.spec.browser": "./node_modules/.bin/openapi --input openapi.yaml --output ./src/api --useOptions --useUnionTypes --client xhr",
+    "generate.spec.browser": "./node_modules/.bin/openapi --input openapi.yaml --output ./src/api --useUnionTypes --client xhr",
     "webpack": "npm run generate.spec.browser && npx webpack --mode=development && npx webpack --mode=production && npm run generate.spec.node"
   },
   "keywords": [],

--- a/src/sideload.ts
+++ b/src/sideload.ts
@@ -1,6 +1,7 @@
 import Docupilot from './docupilot';
 
 import * as _API from './api';
+import { ApiRequestOptions } from './api/core/ApiRequestOptions';
 
 class _Docupilot extends Docupilot {
   readonly AuthTokensService = _API.AuthTokensService;
@@ -15,6 +16,13 @@ class _Docupilot extends Docupilot {
   readonly TemplateDeliveryService = _API.TemplateDeliveryService;
   readonly TemplatesService = _API.TemplatesService;
   readonly UsersService = _API.UsersService;
+
+  configureHeadersInterceptor(getHeaders: () => Record<string, string>) {
+    _API.OpenAPI.HEADERS = async (options: ApiRequestOptions) => {
+      const headers = getHeaders();
+      return Object.assign({}, options.headers || {}, headers);
+    };
+  }
 }
 
 export const client = new _Docupilot();


### PR DESCRIPTION
* avoid using `useOptions` for legacy web-apps
* intercept headers to dynamically configure custom headers per request